### PR TITLE
Load resources according to AA namespace

### DIFF
--- a/lib/active_admin_role/manageable_resource.rb
+++ b/lib/active_admin_role/manageable_resource.rb
@@ -3,7 +3,8 @@ require "set"
 module ActiveAdminRole
   class ManageableResource
     def call
-      ::ActiveAdmin.application.namespaces[:admin].resources.inject([]) do |result, resource|
+      namespace = ::ActiveAdmin.application.default_namespace
+      ::ActiveAdmin.application.namespaces[namespace].resources.inject([]) do |result, resource|
         class_name = resource.controller.resource_class.to_s
         name       = resource.resource_name.name
         actions    = collect_defined_actions(resource)


### PR DESCRIPTION
Fix an issue when namespace is not default but something like:
`config.default_namespace = :cia_admin`