### PR TITLE
Addresses the fact enums with keyword arguments are deprecated

### DIFF
--- a/app/models/active_admin/permission.rb
+++ b/app/models/active_admin/permission.rb
@@ -3,7 +3,7 @@ module ActiveAdmin
     self.table_name = :active_admin_permissions
     role_based_authorizable
 
-    enum state: { cannot: 0, can: 1 }
+    enum :state, { cannot: 0, can: 1 }
 
     belongs_to :managed_resource
     delegate :class_name, :action, :name, :const, :active?, :for_active_admin_page?, to: :managed_resource

--- a/app/models/active_admin/permission.rb
+++ b/app/models/active_admin/permission.rb
@@ -3,7 +3,11 @@ module ActiveAdmin
     self.table_name = :active_admin_permissions
     role_based_authorizable
 
-    enum :state, { cannot: 0, can: 1 }
+    if Rails::VERSION::STRING >= '7.0.0'
+      enum :state, { cannot: 0, can: 1 }
+    else
+      enum state: { cannot: 0, can: 1 }
+    end
 
     belongs_to :managed_resource
     delegate :class_name, :action, :name, :const, :active?, :for_active_admin_page?, to: :managed_resource

--- a/lib/active_admin_role/role_based_authorizable.rb
+++ b/lib/active_admin_role/role_based_authorizable.rb
@@ -3,7 +3,7 @@ module ActiveAdminRole
     extend ActiveSupport::Concern
 
     included do
-      enum role: config.roles
+      enum :role, config.roles
       delegate :super_user_roles, :guest_user_roles, to: :class
       validates :role, presence: true
     end

--- a/lib/active_admin_role/role_based_authorizable.rb
+++ b/lib/active_admin_role/role_based_authorizable.rb
@@ -3,7 +3,12 @@ module ActiveAdminRole
     extend ActiveSupport::Concern
 
     included do
-      enum :role, config.roles
+      if Rails::VERSION::STRING >= '7.0.0'
+        enum :role, config.roles
+      else
+        enum role: config.roles
+      end
+
       delegate :super_user_roles, :guest_user_roles, to: :class
       validates :role, presence: true
     end


### PR DESCRIPTION
Rails 7 introduced a new enum syntax, and starting with Rails 7.2, the old syntax is now deprecated with a warning that it'll be removed in Rails 8. This changes how the `state` and `role` enums are defined in Rails 7+ as to silence the warning and ensure they are compatible with future versions of Rails.